### PR TITLE
Created _dlls folder on build, which fixes an error after cleaning.

### DIFF
--- a/nakefile.nim
+++ b/nakefile.nim
@@ -27,6 +27,7 @@ proc genGodotApi() =
 
 task "build", "Builds the client for the current platform":
   genGodotApi()
+  createDir("_dlls")
   let bitsPostfix = when sizeof(int) == 8: "_64" else: "_32"
   let libFile =
     when defined(windows):


### PR DESCRIPTION
Otherwise running `nake clean; nake build` errors out unless `_dlls` directory is manually created.